### PR TITLE
Fix Parameters for saving png and gif

### DIFF
--- a/watermark.php
+++ b/watermark.php
@@ -201,7 +201,13 @@ class Watermark {
 		$functionTarget = $this->getFunction($imgTarget, 'save');
 
 		# Save image
-		$functionTarget($this->imgSource, $imgTarget, 100);
+		if(preg_match('/^(.*)\.(jpeg|jpg)$/', $imgTarget)){
+			$functionTarget($this->imgSource, $imgTarget, 100);
+		}elseif(preg_match('/^(.*)\.(png)$/', $imgTarget)){
+			$functionTarget($this->imgSource, $imgTarget, 0);
+		}elseif(preg_match('/^(.*)\.(gif)$/', $imgTarget)){
+			$functionTarget($this->imgSource, $imgTarget);
+		}
 
 		# Destroy temp images
 		imagedestroy($this->imgSource);


### PR DESCRIPTION
save function was given quality parameter 100 which is only valid for jpg
png uses 0-9 (compression) https://secure.php.net/manual/en/function.imagepng.php
gif does not have quality parameter https://secure.php.net/manual/en/function.imagegif.php